### PR TITLE
add react 17 as peer depedency

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "peerDependencies": {
     "prop-types": "^15.5.0",
-    "react": "^15.5.0 || ^16.0.0"
+    "react": "^15.5.0 || ^16.0.0 || ^17.0.0"
   },
   "scripts": {
     "prepublish": "webpack --progress",


### PR DESCRIPTION
There is unlikely to be any problems with v17 compatibility. https://reactjs.org/blog/2020/10/20/react-v17.html